### PR TITLE
Update workflow for NR to use liburcu8

### DIFF
--- a/.github/workflows/nr.yml
+++ b/.github/workflows/nr.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Install dependencies
-      run: sudo apt-get update && sudo apt-get install -y libhwloc-dev gnuplot libfuse-dev liburcu-dev liburcu6
+      run: sudo apt-get update && sudo apt-get install -y libhwloc-dev gnuplot libfuse-dev liburcu-dev liburcu8
     - uses: actions/checkout@v2.4.0
     - name: Install rust toolchain
       working-directory: ./node-replication


### PR DESCRIPTION
The package `liburcu6` is no longer available in Ubuntu Jammy, but `liburcu8` is. Updated to newer version for pipelines.

```
E: Unable to locate package liburcu6
```