### PR TITLE
Nr dynamic replication

### DIFF
--- a/.github/workflows/nr.yml
+++ b/.github/workflows/nr.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Install dependencies
-      run: sudo apt-get update && sudo apt-get install -y libhwloc-dev gnuplot libfuse-dev liburcu-dev liburcu6
+      run: sudo apt-get update && sudo apt-get install -y libhwloc-dev gnuplot libfuse-dev liburcu-dev liburcu8
     - uses: actions/checkout@v2.4.0
     - name: Install rust toolchain
       working-directory: ./node-replication

--- a/bench_utils/src/mkbench.rs
+++ b/bench_utils/src/mkbench.rs
@@ -140,7 +140,7 @@ pub trait DsInterface {
     ) -> <Self::D as Dispatch>::Response;
 }
 
-impl<'a, T: Dispatch + Sync + Default> DsInterface for NodeReplicated<T> {
+impl<'a, T: Dispatch + Sync + Default + Clone> DsInterface for NodeReplicated<T> {
     type D = T;
 
     fn new(replicas: NonZeroUsize, _logs: NonZeroUsize, log_size: usize) -> Arc<Self> {
@@ -235,7 +235,7 @@ pub fn baseline_comparison<R: DsInterface>(
     >,
     log_size: usize,
 ) where
-    R::D: Dispatch + Sync + Default,
+    R::D: Dispatch + Sync + Default + Clone,
     <R::D as Dispatch>::WriteOperation: Send + Sync,
     <R::D as Dispatch>::ReadOperation<'static>: Sync + Send + Clone,
     <R::D as Dispatch>::Response: Send,

--- a/node-replication/Cargo.toml
+++ b/node-replication/Cargo.toml
@@ -21,6 +21,7 @@ crossbeam-utils = {version = "0.8.5", default-features = false}
 # renamed to avoid confusion with our own `log` modules:
 logging = { version = "0.4", package = "log" }
 static_assertions = "1.1.0"
+bm = { git = "https://github.com/reynoldsbd/bm" }
 
 [target.'cfg(loom)'.dependencies]
 arr_macro = "0.1.3"

--- a/node-replication/Cargo.toml
+++ b/node-replication/Cargo.toml
@@ -55,7 +55,7 @@ futures =  { version = "0.3.17" }
 debug = true
 
 [features]
-default = ["async"]
+default = []
 async = []
 
 # Benchmark features (not intended for public use, no impact on library code)

--- a/node-replication/benches/vspace.rs
+++ b/node-replication/benches/vspace.rs
@@ -135,6 +135,7 @@ impl fmt::Display for MapAction {
     }
 }
 
+#[derive(Clone)]
 pub struct VSpace {
     pub pml4: Pin<Box<PML4>>,
     allocs: Vec<(*mut u8, usize)>,
@@ -487,7 +488,7 @@ enum OpcodeRd {
     Identify(u64),
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 struct VSpaceDispatcher {
     vspace: VSpace,
 }

--- a/node-replication/examples/cnr_btreeset.rs
+++ b/node-replication/examples/cnr_btreeset.rs
@@ -1,0 +1,157 @@
+// Copyright © 2019-2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! A minimal example that impements a replicated BTreeSet.
+#![feature(generic_associated_types)]
+
+use crossbeam_skiplist::SkipSet;
+
+use std::sync::Arc;
+
+use node_replication::cnr::{Dispatch, Log, LogMapper, LogMetaData, Replica};
+
+#[derive(Default)]
+struct CnrBtreeSet {
+    storage: SkipSet<u64>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+enum Modify {
+    Put(u64),
+    Delete(u64),
+}
+
+impl LogMapper for Modify {
+    fn hash(&self, _nlogs: usize, logs: &mut Vec<usize>) {
+        logs.push(0);
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+enum Access {
+    Get(u64),
+    Contains(u64),
+}
+
+impl LogMapper for Access {
+    fn hash(&self, _nlogs: usize, logs: &mut Vec<usize>) {
+        logs.push(0);
+    }
+}
+
+impl Dispatch for CnrBtreeSet {
+    type ReadOperation<'rop> = Access;
+    type WriteOperation = Modify;
+    type Response = Option<u64>;
+
+    fn dispatch<'rop>(&self, op: Self::ReadOperation<'rop>) -> Self::Response {
+        match op {
+            Access::Get(key) => self.storage.get(&key).map(|v| *v),
+            Access::Contains(key) => {
+                let response = self.storage.contains(&key);
+                Some(response as u64)
+            }
+        }
+    }
+
+    fn dispatch_mut(&self, op: Self::WriteOperation) -> Self::Response {
+        match op {
+            Modify::Put(key) => {
+                let response = self.storage.insert(key);
+                Some(*response)
+            }
+            Modify::Delete(key) => {
+                let response = self.storage.remove(&key).unwrap();
+                Some(*response)
+            }
+        }
+    }
+}
+
+/// We initialize a log, and two replicas for a B-tree, register with the replica
+/// and then execute operations.
+fn main() {
+    const N_OPS: u64 = 10_000;
+    // The operation log for storing `WriteOperation`, it has a size of 2 MiB:
+    let log = Arc::new(
+        Log::<<CnrBtreeSet as Dispatch>::WriteOperation>::new_with_bytes(
+            2 * 1024 * 1024,
+            LogMetaData::new(1),
+        ),
+    );
+
+    // Create two replicas of the b-tree
+    let replica1 = Replica::<CnrBtreeSet>::new(vec![log.clone()]);
+    let replica2 = Replica::<CnrBtreeSet>::new(vec![log.clone()]);
+
+    // The replica executes Modify or Access operations by calling
+    // 'execute_mut' and `execute`. Eventually they end up in the `Dispatch` trait.
+    let thread_loop = |replica: &Arc<Replica<CnrBtreeSet>>, starting_point: u64, ridx| {
+        for i in starting_point..starting_point + N_OPS {
+            let _r = match i % 4 {
+                0 => {
+                    let response = replica.execute_mut(Modify::Put(i), ridx);
+                    assert_eq!(response, Some(i));
+                    response
+                }
+                1 => {
+                    let response = replica.execute(Access::Contains(i - 1), ridx);
+                    assert_eq!(response, Some(1));
+                    response
+                }
+                2 => {
+                    let response = replica.execute(Access::Get(i - 2), ridx);
+                    assert_eq!(response, Some(i - 2));
+                    response
+                }
+                3 => {
+                    let response = replica.execute_mut(Modify::Delete(i - 3), ridx);
+                    assert_eq!(response, Some(i - 3));
+                    response
+                }
+
+                _ => unreachable!(),
+            };
+        }
+    };
+
+    // Finally, we spawn three threads that issue operations, thread 1 and 2
+    // will use replica1 and thread 3 will use replica 2:
+    let mut threads = Vec::with_capacity(3);
+    let replica11 = replica1.clone();
+    threads.push(
+        std::thread::Builder::new()
+            .name("thread 1".to_string())
+            .spawn(move || {
+                let ridx = replica11.register().expect("Unable to register with log");
+                thread_loop(&replica11, 0, ridx);
+            }),
+    );
+
+    let replica12 = replica1.clone();
+    threads.push(
+        std::thread::Builder::new()
+            .name("thread 2".to_string())
+            .spawn(move || {
+                let ridx = replica12.register().expect("Unable to register with log");
+                thread_loop(&replica12, 100000, ridx);
+            }),
+    );
+
+    threads.push(
+        std::thread::Builder::new()
+            .name("thread 3".to_string())
+            .spawn(move || {
+                let ridx = replica2.register().expect("Unable to register with log");
+                thread_loop(&replica2, 200000, ridx);
+            }),
+    );
+
+    // Wait for all the threads to finish
+    for thread in threads {
+        thread
+            .expect("all threads should complete")
+            .join()
+            .unwrap_or_default();
+    }
+}

--- a/node-replication/examples/nr_async_hashmap.rs
+++ b/node-replication/examples/nr_async_hashmap.rs
@@ -17,6 +17,7 @@ use node_replication::nr::NodeReplicated;
 const CAPACITY: usize = 32;
 
 /// The node-replicated hashmap uses a std hashmap internally.
+#[derive(Clone)]
 struct NrHashMap {
     storage: HashMap<usize, usize>,
 }

--- a/node-replication/examples/nr_btreeset.rs
+++ b/node-replication/examples/nr_btreeset.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use node_replication::nr::Dispatch;
 use node_replication::nr::NodeReplicated;
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 struct NrBtreeSet {
     storage: BTreeSet<u64>,
 }

--- a/node-replication/examples/nr_dynamic_replica.rs
+++ b/node-replication/examples/nr_dynamic_replica.rs
@@ -1,0 +1,142 @@
+// Copyright © 2019-2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! An example that dynamically varies the amount of replicas over time.
+#![feature(generic_associated_types)]
+
+use std::collections::HashMap;
+use std::num::NonZeroUsize;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::sync::RwLock;
+
+use node_replication::nr::Dispatch;
+use node_replication::nr::NodeReplicated;
+
+/// The node-replicated hashmap uses a std hashmap internally.
+#[derive(Default, Clone)]
+struct NrHashMap {
+    storage: HashMap<u64, u64>,
+}
+
+/// We support a mutable put operation to insert a value for a given key.
+#[derive(Clone, Debug, PartialEq)]
+enum Modify {
+    /// Insert (key, value)
+    Put(u64, u64),
+}
+
+/// We support an immutable read operation to lookup a key from the hashmap.
+#[derive(Clone, Debug, PartialEq)]
+enum Access {
+    // Retrieve key.
+    Get(u64),
+}
+
+/// The Dispatch trait executes `ReadOperation` (our Access enum) and `WriteOperation`
+/// (our `Modify` enum) against the replicated data-structure.
+impl Dispatch for NrHashMap {
+    type ReadOperation<'rop> = Access;
+    type WriteOperation = Modify;
+    type Response = Option<u64>;
+
+    /// The `dispatch` function contains the logic for the immutable operations.
+    fn dispatch<'rop>(&self, op: Self::ReadOperation<'rop>) -> Self::Response {
+        match op {
+            Access::Get(key) => self.storage.get(&key).map(|v| *v),
+        }
+    }
+
+    /// The `dispatch_mut` function contains the logic for the mutable operations.
+    fn dispatch_mut(&mut self, op: Self::WriteOperation) -> Self::Response {
+        match op {
+            Modify::Put(key, value) => self.storage.insert(key, value),
+        }
+    }
+}
+
+fn main() {
+    // Setup logging and some constants.
+    let _r = env_logger::try_init();
+
+    const NUM_THREADS: usize = 4;
+
+    // We start with 4 replicas.
+    let initial_replicas: NonZeroUsize = NonZeroUsize::new(4).unwrap();
+    let finished = Arc::new(AtomicBool::new(false));
+
+    // The node-replicated hashmap is wrapped in an Arc<RwLock<>> to allow for
+    // the RwLock is currently needed because `add_replica` and `remove_replica`
+    // are not yet thread-safe. We will remove this in the future:
+    let nrht = Arc::new(RwLock::new(
+        NodeReplicated::<NrHashMap>::new(initial_replicas, |_rid| 0).unwrap(),
+    ));
+
+    // The worker threads will just issue operations until the `finished` flag is set.
+    let thread_loop =
+        |replica: Arc<RwLock<NodeReplicated<NrHashMap>>>, ttkn, finished: Arc<AtomicBool>| {
+            let mut i = 0;
+            while !finished.load(Ordering::Relaxed) {
+                let _r = match i % 2 {
+                    0 => replica
+                        .read()
+                        .unwrap()
+                        .execute_mut(Modify::Put(i, i + 1), ttkn),
+                    1 => {
+                        let response = replica.read().unwrap().execute(Access::Get(i - 1), ttkn);
+                        assert_eq!(response, Some(i));
+                        response
+                    }
+                    _ => unreachable!(),
+                };
+                i += 1;
+
+                if i % 1_000_000 == 0 {
+                    println!("Thread {:?} executed {} operations", ttkn, i);
+                }
+            }
+        };
+
+    let mut threads = Vec::with_capacity(NUM_THREADS);
+    for t in 0..NUM_THREADS {
+        let nrht_cln = nrht.clone();
+        let finished = finished.clone();
+        threads.push(std::thread::spawn(move || {
+            let ttkn = nrht_cln
+                .read()
+                .unwrap()
+                .register(t % initial_replicas)
+                .expect(
+                    format!(
+                        "Unable to register thread with replica {}",
+                        t % initial_replicas
+                    )
+                    .as_str(),
+                );
+            thread_loop(nrht_cln, ttkn, finished);
+        }));
+    }
+
+    // First we move from 4 to 1 replica by removing one every 3 seconds:
+    for next_rid in &[3, 2, 1] {
+        std::thread::sleep(std::time::Duration::from_secs(3));
+        println!("About to remove replica {:?}", next_rid);
+        let x = nrht.write().unwrap().remove_replica(*next_rid).unwrap();
+        println!("Removed replica {:?}", x);
+    }
+
+    // Then we increase back from 1 to 4 replicas:
+    for next_rid in &[1, 2, 3] {
+        std::thread::sleep(std::time::Duration::from_secs(3));
+        println!("About to add replica {:?}", next_rid);
+        let x = nrht.write().unwrap().add_replica().unwrap();
+        println!("Added replica {:?}", x);
+    }
+
+    finished.store(true, Ordering::Relaxed);
+    // Wait for all the threads to finish
+    for thread in threads {
+        thread.join().unwrap();
+    }
+}

--- a/node-replication/examples/nr_hashmap.rs
+++ b/node-replication/examples/nr_hashmap.rs
@@ -12,7 +12,7 @@ use node_replication::nr::Dispatch;
 use node_replication::nr::NodeReplicated;
 
 /// The node-replicated hashmap uses a std hashmap internally.
-#[derive(Default)]
+#[derive(Default, Clone)]
 struct NrHashMap {
     storage: HashMap<u64, u64>,
 }

--- a/node-replication/examples/nr_stack.rs
+++ b/node-replication/examples/nr_stack.rs
@@ -28,6 +28,7 @@ enum Access {
 }
 
 /// The actual stack is implemented with a (single-threaded) Vec.
+#[derive(Clone)]
 struct Stack<T>
 where
     T: Default,

--- a/node-replication/src/lib.rs
+++ b/node-replication/src/lib.rs
@@ -36,6 +36,7 @@ pub mod replica;
 
 pub mod cnr;
 pub mod nr;
+pub mod simdr;
 
 #[cfg(doctest)]
 mod test_readme {

--- a/node-replication/src/lib.rs
+++ b/node-replication/src/lib.rs
@@ -36,7 +36,6 @@ pub mod replica;
 
 pub mod cnr;
 pub mod nr;
-pub mod simdr;
 
 #[cfg(doctest)]
 mod test_readme {

--- a/node-replication/src/log.rs
+++ b/node-replication/src/log.rs
@@ -4,6 +4,10 @@
 //! Contains the shared Log, in a nutshell it's a multi-producer, multi-consumer
 //! circular-buffer.
 
+extern crate std;
+
+use std::collections::HashMap;
+
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 
@@ -14,6 +18,7 @@ use core::mem::size_of;
 #[cfg(not(loom))]
 use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
+use bm::AtomicBitmap;
 use crossbeam_utils::CachePadded;
 #[cfg(loom)]
 pub use loom::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -153,16 +158,17 @@ where
     /// Required for garbage collection; since replicas make progress over the log
     /// independently, we want to make sure that we don't garbage collect operations
     /// that haven't been executed by all replicas.
-    pub(crate) ltails: [CachePadded<AtomicUsize>; MAX_REPLICAS_PER_LOG],
+    pub(crate) ltails: HashMap<usize, CachePadded<AtomicUsize>>,
 
     /// Identifier that will be allocated to the next replica that registers with
     /// this Log. Also required to correctly index into ltails above.
-    pub(crate) next: CachePadded<AtomicUsize>,
+    pub replica_inventory: Box<dyn AtomicBitmap>,
 
     /// Array consisting of local alive masks for each registered replica. Required
     /// because replicas make independent progress over the log, so we need to
     /// track log wrap-arounds for each of them separately.
-    pub(crate) lmasks: [CachePadded<Cell<bool>>; MAX_REPLICAS_PER_LOG],
+    // pub(crate) lmasks: [CachePadded<Cell<bool>>; MAX_REPLICAS_PER_LOG],
+    pub(crate) lmasks: HashMap<usize, CachePadded<Cell<bool>>>,
 
     /// Meta-data used by log implementations.
     pub(crate) metadata: LM,
@@ -242,19 +248,30 @@ where
         #[allow(clippy::declare_interior_mutable_const)]
         const LMASK_DEFAULT: CachePadded<Cell<bool>> = CachePadded::new(Cell::new(true));
 
+        let mut lmask_init = HashMap::with_capacity(MAX_REPLICAS_PER_LOG);
+        for i in 0..MAX_REPLICAS_PER_LOG {
+            lmask_init.insert(i, LMASK_DEFAULT);
+        }
+
         #[cfg(not(loom))]
         {
             #[allow(clippy::declare_interior_mutable_const)]
             const LTAIL_DEFAULT: CachePadded<AtomicUsize> = CachePadded::new(AtomicUsize::new(0));
+
+            let mut ltails_init = HashMap::with_capacity(MAX_REPLICAS_PER_LOG);
+
+            for i in 0..MAX_REPLICAS_PER_LOG {
+                ltails_init.insert(i, LTAIL_DEFAULT);
+            }
 
             Log {
                 slog: raw,
                 head: CachePadded::new(AtomicUsize::new(0usize)),
                 tail: CachePadded::new(AtomicUsize::new(0usize)),
                 ctail: CachePadded::new(AtomicUsize::new(0usize)),
-                ltails: [LTAIL_DEFAULT; MAX_REPLICAS_PER_LOG],
-                next: CachePadded::new(AtomicUsize::new(1usize)),
-                lmasks: [LMASK_DEFAULT; MAX_REPLICAS_PER_LOG],
+                ltails: ltails_init,
+                replica_inventory: Box::new(AtomicUsize::new(1usize)),
+                lmasks: lmask_init,
                 metadata,
             }
         }
@@ -264,14 +281,22 @@ where
         #[cfg(loom)]
         {
             use arr_macro::arr;
+
+            const LTAIL_DEFAULT: CachePadded<AtomicUsize> = CachePadded::new(AtomicUsize::new(0));
+
+            let mut ltails_init = HashMap::with_capacity(3);
+
+            for i in 0..3 {
+                ltails_init.insert(i, LTAIL_DEFAULT);
+            }
             Log {
                 slog: raw,
                 head: CachePadded::new(AtomicUsize::new(0usize)),
                 tail: CachePadded::new(AtomicUsize::new(0usize)),
                 ctail: CachePadded::new(AtomicUsize::new(0usize)),
-                ltails: arr![CachePadded::new(AtomicUsize::new(0)); 3], // MAX_REPLICAS_PER_LOG
-                next: CachePadded::new(AtomicUsize::new(1usize)),
-                lmasks: [LMASK_DEFAULT; MAX_REPLICAS_PER_LOG],
+                ltails: ltails_init,
+                replica_inventory: Box::new(AtomicUsize::new(1usize)),
+                lmasks: HashMap::with_capacity(MAX_REPLICAS_PER_LOG),
                 metadata,
             }
         }
@@ -379,25 +404,17 @@ where
     /// let idx = l.register().expect("Failed to register with the Log.");
     /// ```
     pub fn register(&self) -> Option<LogToken> {
-        // Loop until we either run out of identifiers or we manage to increment `next`.
-        loop {
-            let n = self.next.load(Ordering::Relaxed);
-
-            // Check if we've exceeded the maximum number of replicas the log can support.
-            if n > MAX_REPLICAS_PER_LOG {
-                return None;
-            };
-
-            if self
-                .next
-                .compare_exchange_weak(n, n + 1, Ordering::SeqCst, Ordering::SeqCst)
-                != Ok(n)
+        for replica_id in 0..=MAX_REPLICAS_PER_LOG {
+            if !self
+                .replica_inventory
+                .load_bit(replica_id, Ordering::Relaxed)
             {
-                continue;
-            };
-
-            return Some(LogToken(n));
+                self.replica_inventory
+                    .compare_and_swap(replica_id, false, true, Ordering::Relaxed);
+                return Some(LogToken(replica_id));
+            }
         }
+        None
     }
 
     /// Returns a physical index given a logical index into the shared log.
@@ -406,23 +423,38 @@ where
         logical & (self.slog.len() - 1)
     }
 
+    pub(crate) fn replica_count(&self) -> usize {
+        let mut count = 0;
+        for replica_id in 0..MAX_REPLICAS_PER_LOG {
+            if self
+                .replica_inventory
+                .load_bit(replica_id, Ordering::Relaxed)
+            {
+                count += 1;
+            }
+        }
+        count
+    }
+
     /// Loops over all `ltails` and finds the replica with the lowest tail.
     ///
     /// # Returns
     /// The ID (in `LogToken`) of the replica with the lowest tail and the
     /// corresponding/lowest tail `idx` in the `Log`.
     pub(crate) fn find_min_tail(&self) -> (usize, usize) {
-        let r = self.next.load(Ordering::Relaxed);
-        let (mut min_replica_idx, mut min_local_tail) = (0, self.ltails[0].load(Ordering::Relaxed));
+        let (mut min_replica_idx, mut min_local_tail) =
+            (0, self.ltails[&0].load(Ordering::Relaxed));
 
         // Find the smallest local tail across all replicas.
-        for idx in 1..r {
-            let cur_local_tail = self.ltails[idx - 1].load(Ordering::Relaxed);
-            //info!("Replica {} cur_local_tail {}.", idx - 1, cur_local_tail);
+        for idx in 1..MAX_REPLICAS_PER_LOG {
+            if self.replica_inventory.get_bit(idx) {
+                let cur_local_tail = self.ltails[&(idx - 1)].load(Ordering::Relaxed);
+                //info!("Replica {} cur_local_tail {}.", idx - 1, cur_local_tail);
 
-            if cur_local_tail < min_local_tail {
-                min_local_tail = cur_local_tail;
-                min_replica_idx = idx - 1;
+                if cur_local_tail < min_local_tail {
+                    min_local_tail = cur_local_tail;
+                    min_replica_idx = idx - 1;
+                }
             }
         }
 
@@ -435,12 +467,12 @@ where
     /// The ID (in `LogToken`) of the replica with the highest tail and the
     /// corresponding/highest tail `idx` in the `Log`.
     pub(crate) fn find_max_tail(&self) -> (usize, usize) {
-        let r = self.next.load(Ordering::Relaxed);
-        let (mut max_replica_idx, mut max_local_tail) = (0, self.ltails[0].load(Ordering::Relaxed));
+        let (mut max_replica_idx, mut max_local_tail) =
+            (0, self.ltails[&0].load(Ordering::Relaxed));
 
         // Find the local tail across all replicas.
-        for idx in 1..r {
-            let cur_local_tail = self.ltails[idx - 1].load(Ordering::Relaxed);
+        for idx in 1..MAX_REPLICAS_PER_LOG {
+            let cur_local_tail = self.ltails[&(idx - 1)].load(Ordering::Relaxed);
             //info!("Replica {} cur_local_tail {}.", idx - 1, cur_local_tail);
 
             if cur_local_tail > max_local_tail {
@@ -469,12 +501,17 @@ where
         // First, reset global metadata.
         self.head.store(0, Ordering::SeqCst);
         self.tail.store(0, Ordering::SeqCst);
-        self.next.store(1, Ordering::SeqCst);
+        for i in 0..MAX_REPLICAS_PER_LOG {
+            self.replica_inventory
+                .compare_and_swap(i, true, false, Ordering::Relaxed);
+        }
+        self.replica_inventory
+            .compare_and_swap(0, false, true, Ordering::Relaxed);
 
         // Next, reset replica-local metadata.
         for r in 0..MAX_REPLICAS_PER_LOG {
-            self.ltails[r].store(0, Ordering::Relaxed);
-            self.lmasks[r].set(true);
+            self.ltails[&r].store(0, Ordering::Relaxed);
+            self.lmasks[&r].set(true);
         }
 
         // Next, free up all log entries. Use pointers to avoid memcpy and speed up the
@@ -546,7 +583,7 @@ where
     /// ```
     #[inline(always)]
     pub(crate) fn is_replica_synced_for_reads(&self, idx: &LogToken, ctail: usize) -> bool {
-        self.ltails[idx.0 - 1].load(Ordering::Relaxed) >= ctail
+        self.ltails[&(idx.0 - 1)].load(Ordering::Relaxed) >= ctail
     }
 
     /// This method returns the current ctail value for the log.
@@ -608,22 +645,22 @@ mod tests {
 
     // Tests if a small log can be correctly constructed.
     #[test]
-    fn test_log_create() {
+    fn test_std_log_create() {
         let l = Log::<Operation, (), ()>::new_with_bytes(1024 * 1024, ());
         let n = (1024 * 1024) / Log::<Operation, (), ()>::entry_size();
         assert_eq!(l.slog.len(), n);
         assert_eq!(l.head.load(Ordering::Relaxed), 0);
         assert_eq!(l.tail.load(Ordering::Relaxed), 0);
-        assert_eq!(l.next.load(Ordering::Relaxed), 1);
         assert_eq!(l.ctail.load(Ordering::Relaxed), 0);
         assert_eq!(l.metadata, ());
 
         for i in 0..MAX_REPLICAS_PER_LOG {
-            assert_eq!(l.ltails[i].load(Ordering::Relaxed), 0);
+            assert_eq!(l.ltails[&i].load(Ordering::Relaxed), 0);
         }
 
         for i in 0..MAX_REPLICAS_PER_LOG {
-            assert_eq!(l.lmasks[i].get(), true);
+            std::dbg!(i);
+            assert_eq!(l.lmasks[&i].get(), true);
         }
     }
 
@@ -667,15 +704,14 @@ mod tests {
         assert_eq!(l.slog.len(), n);
         assert_eq!(l.head.load(Ordering::Relaxed), 0);
         assert_eq!(l.tail.load(Ordering::Relaxed), 0);
-        assert_eq!(l.next.load(Ordering::Relaxed), 1);
         assert_eq!(l.ctail.load(Ordering::Relaxed), 0);
 
         for i in 0..MAX_REPLICAS_PER_LOG {
-            assert_eq!(l.ltails[i].load(Ordering::Relaxed), 0);
+            assert_eq!(l.ltails[&i].load(Ordering::Relaxed), 0);
         }
 
         for i in 0..MAX_REPLICAS_PER_LOG {
-            assert_eq!(l.lmasks[i].get(), true);
+            assert_eq!(l.lmasks[&i].get(), true);
         }
     }
 
@@ -691,7 +727,7 @@ mod tests {
     fn test_log_register() {
         let l = Log::<Operation, (), ()>::new_with_bytes(1024, ());
         assert_eq!(l.register(), Some(LogToken(1)));
-        assert_eq!(l.next.load(Ordering::Relaxed), 2);
+        assert_eq!(l.replica_count(), 2);
     }
 
     // Tests that we can register exactly `MAX_REPLICAS_PER_LOG` replicas.
@@ -710,11 +746,10 @@ mod tests {
         let l = Log::<Operation, (), ()>::default();
         let _lt = l.register().unwrap();
 
-        l.next.store(5, Ordering::Relaxed);
-        l.ltails[0].store(1023, Ordering::Relaxed);
-        l.ltails[1].store(224, Ordering::Relaxed);
-        l.ltails[2].store(4096, Ordering::Relaxed);
-        l.ltails[3].store(799, Ordering::Relaxed);
+        l.ltails[&0].store(1023, Ordering::Relaxed);
+        l.ltails[&1].store(224, Ordering::Relaxed);
+        l.ltails[&2].store(4096, Ordering::Relaxed);
+        l.ltails[&3].store(799, Ordering::Relaxed);
 
         assert_eq!(l.find_max_tail(), (2, 4096))
     }
@@ -725,11 +760,15 @@ mod tests {
         let l = Log::<Operation, (), ()>::default();
         let _lt = l.register().unwrap();
 
-        l.next.store(5, Ordering::Relaxed);
-        l.ltails[0].store(1023, Ordering::Relaxed);
-        l.ltails[1].store(224, Ordering::Relaxed);
-        l.ltails[2].store(4096, Ordering::Relaxed);
-        l.ltails[3].store(799, Ordering::Relaxed);
+        for i in 0..4 {
+            l.replica_inventory
+                .compare_and_swap(i, false, true, Ordering::Relaxed);
+        }
+
+        l.ltails[&0].store(1023, Ordering::Relaxed);
+        l.ltails[&1].store(224, Ordering::Relaxed);
+        l.ltails[&2].store(4096, Ordering::Relaxed);
+        l.ltails[&3].store(799, Ordering::Relaxed);
 
         assert_eq!(l.find_min_tail(), (1, 224))
     }

--- a/node-replication/src/log.rs
+++ b/node-replication/src/log.rs
@@ -52,7 +52,7 @@ const_assert!(DEFAULT_LOG_BYTES.is_power_of_two());
 /// our system Can't make it arbitrarily high as it will lead to more memory
 /// overheads / bigger structs.
 #[cfg(not(loom))]
-pub const MAX_REPLICAS_PER_LOG: usize = 16;
+pub const MAX_REPLICAS_PER_LOG: usize = 8;
 #[cfg(loom)] // Otherwise uses too much stack space wich crashes in loom...
 pub const MAX_REPLICAS_PER_LOG: usize = 3;
 

--- a/node-replication/src/nr/rwlock.rs
+++ b/node-replication/src/nr/rwlock.rs
@@ -67,7 +67,7 @@ pub struct ReadGuard<'a, T: Sized + Sync + Clone + 'a> {
 
 /// A write-guard that can be used to write to the underlying data structure. All
 /// reads will be blocked until this is dropped.
-pub struct WriteGuard<'a, T: Sized + Sync +  Clone + 'a> {
+pub struct WriteGuard<'a, T: Sized + Sync + Clone + 'a> {
     /// A reference to the Rwlock wrapping the data-structure.
     lock: &'a RwLock<T>,
 }

--- a/node-replication/src/nr/rwlock.rs
+++ b/node-replication/src/nr/rwlock.rs
@@ -441,7 +441,7 @@ mod tests {
     #[test]
     fn test_parallel_readers() {
         let lock = Arc::new(RwLock::<usize>::default());
-        let t = 100;
+        let t = MAX_READER_THREADS;
 
         unsafe {
             *lock.data.get() = t;

--- a/node-replication/src/nr/rwlock.rs
+++ b/node-replication/src/nr/rwlock.rs
@@ -42,7 +42,7 @@ const RLOCK_DEFAULT: CachePadded<AtomicUsize> = CachePadded::new(AtomicUsize::ne
 /// Calling `write()` returns a write-guard that can be used to safely mutate `T`.
 pub struct RwLock<T>
 where
-    T: Sized + Sync,
+    T: Sized + Sync + Clone,
 {
     /// The writer lock. There can be at most one writer at any given point of time.
     wlock: CachePadded<AtomicBool>,
@@ -56,7 +56,7 @@ where
 
 /// A read-guard that can be used to read the underlying data structure. Writes on
 /// the data structure will be blocked as long as one of these is lying around.
-pub struct ReadGuard<'a, T: Sized + Sync + 'a> {
+pub struct ReadGuard<'a, T: Sized + Sync + Clone + 'a> {
     /// Id of the thread that acquired this guard. Required at drop time so that
     /// we can release the appropriate read lock.
     tid: usize,
@@ -67,14 +67,14 @@ pub struct ReadGuard<'a, T: Sized + Sync + 'a> {
 
 /// A write-guard that can be used to write to the underlying data structure. All
 /// reads will be blocked until this is dropped.
-pub struct WriteGuard<'a, T: Sized + Sync + 'a> {
+pub struct WriteGuard<'a, T: Sized + Sync +  Clone + 'a> {
     /// A reference to the Rwlock wrapping the data-structure.
     lock: &'a RwLock<T>,
 }
 
 impl<T> Default for RwLock<T>
 where
-    T: Sized + Default + Sync,
+    T: Sized + Default + Sync + Clone,
 {
     /// Returns a new instance of a RwLock. Default constructs the
     /// underlying data structure.
@@ -89,7 +89,7 @@ where
 
 impl<T> RwLock<T>
 where
-    T: Sized + Sync,
+    T: Sized + Sync + Clone,
 {
     /// Returns a new instance of a RwLock. Default constructs the
     /// underlying data structure.
@@ -218,14 +218,14 @@ where
     }
 }
 
-impl<'rwlock, T: Sized + Sync> ReadGuard<'rwlock, T> {
+impl<'rwlock, T: Sized + Sync + Clone> ReadGuard<'rwlock, T> {
     /// Returns a read guard over a passed in reader-writer lock.
     unsafe fn new(lock: &'rwlock RwLock<T>, tid: usize) -> ReadGuard<'rwlock, T> {
         ReadGuard { tid, lock }
     }
 }
 
-impl<'rwlock, T: Sized + Sync> WriteGuard<'rwlock, T> {
+impl<'rwlock, T: Sized + Sync + Clone> WriteGuard<'rwlock, T> {
     /// Returns a write guard over a passed in reader-writer lock.
     unsafe fn new(lock: &'rwlock RwLock<T>) -> WriteGuard<'rwlock, T> {
         WriteGuard { lock }
@@ -235,11 +235,11 @@ impl<'rwlock, T: Sized + Sync> WriteGuard<'rwlock, T> {
 /// `Sync` trait allows `RwLock` to be shared between threads. The `read()` and
 /// `write()` logic ensures that we will never have threads writing to and
 /// reading from the underlying data structure simultaneously.
-unsafe impl<T: Sized + Sync> Sync for RwLock<T> {}
+unsafe impl<T: Sized + Sync + Clone> Sync for RwLock<T> {}
 
 /// This `Deref` trait allows a thread to use T from a ReadGuard.
 /// ReadGuard can only be dereferenced into an immutable reference.
-impl<T: Sized + Sync> Deref for ReadGuard<'_, T> {
+impl<T: Sized + Sync + Clone> Deref for ReadGuard<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &T {
@@ -249,7 +249,7 @@ impl<T: Sized + Sync> Deref for ReadGuard<'_, T> {
 
 /// This `Deref` trait allows a thread to use T from a WriteGuard.
 /// This allows us to dereference an immutable reference.
-impl<T: Sized + Sync> Deref for WriteGuard<'_, T> {
+impl<T: Sized + Sync + Clone> Deref for WriteGuard<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &T {
@@ -259,7 +259,7 @@ impl<T: Sized + Sync> Deref for WriteGuard<'_, T> {
 
 /// This `DerefMut` trait allow a thread to use T from a WriteGuard.
 /// This allows us to dereference a mutable reference.
-impl<T: Sized + Sync> DerefMut for WriteGuard<'_, T> {
+impl<T: Sized + Sync + Clone> DerefMut for WriteGuard<'_, T> {
     fn deref_mut(&mut self) -> &mut T {
         unsafe { &mut *self.lock.data.get() }
     }
@@ -267,7 +267,7 @@ impl<T: Sized + Sync> DerefMut for WriteGuard<'_, T> {
 
 /// This `Drop` trait implements the unlock logic for a reader lock. Once the `ReadGuard`
 /// goes out of scope, the corresponding read lock is marked as released.
-impl<T: Sized + Sync> Drop for ReadGuard<'_, T> {
+impl<T: Sized + Sync + Clone> Drop for ReadGuard<'_, T> {
     fn drop(&mut self) {
         unsafe {
             let tid = self.tid;
@@ -278,7 +278,7 @@ impl<T: Sized + Sync> Drop for ReadGuard<'_, T> {
 
 /// This `Drop` trait implements the unlock logic for a writer lock. Once the `WriteGuard`
 /// goes out of scope, the corresponding write lock is marked as released.
-impl<T: Sized + Sync> Drop for WriteGuard<'_, T> {
+impl<T: Sized + Sync + Clone> Drop for WriteGuard<'_, T> {
     fn drop(&mut self) {
         unsafe {
             self.lock.write_unlock();

--- a/node-replication/src/replica.rs
+++ b/node-replication/src/replica.rs
@@ -11,7 +11,7 @@ use static_assertions::const_assert;
 /// [`crate::nr::Replica::register()`] or [`crate::cnr::Replica::register()`]
 /// function will start to return None.
 #[cfg(not(loom))]
-pub const MAX_THREADS_PER_REPLICA: usize = 256;
+pub const MAX_THREADS_PER_REPLICA: usize = 32;
 #[cfg(loom)]
 pub const MAX_THREADS_PER_REPLICA: usize = 2;
 // MAX_THREADS_PER_REPLICA must be a power of two
@@ -46,7 +46,7 @@ pub type ThreadIdx = usize;
 /// and returned again by [`crate::nr::Replica::execute`] and
 /// [`crate::nr::Replica::execute_mut`]. However it feels like this would hurt
 /// API ergonomics a lot.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub struct ReplicaToken(pub(crate) ThreadIdx);
 
 /// Make it harder to accidentially use the same ReplicaToken on multiple


### PR DESCRIPTION
This addresses [issue 52](https://github.com/vmware/node-replication/issues/52). 

We've added  `add_replica` and `remove_replica` to the `NodeReplicated`.  Thread context is held within the replica .  The number of new replicas are limited via `MAX_REPLICAS_PER_LOG`.